### PR TITLE
Solve Unicode character parsing error

### DIFF
--- a/ipynb_output_filter.py
+++ b/ipynb_output_filter.py
@@ -4,6 +4,9 @@ import sys
 
 version = None
 
+reload(sys)  
+sys.setdefaultencoding('utf8')
+
 try:
     # Jupyter
     from jupyter_nbformat import reads, write


### PR DESCRIPTION
Small update to solve the Unicode parsing error:

```
Traceback (most recent call last):
  File "/Users/XXX/bin/ipynb_output_filter.py", line 33, in <module>
    write(json_in, sys.stdout, NO_CONVERT)
  File "/Users/XXX/anaconda/lib/python2.7/site-packages/IPython/nbformat/__init__.py", line 161, in write
    fp.write(s)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2014' in position 11549: ordinal not in range(128)
```
