### PR TITLE
Use new package name for nbformat.

### DIFF
--- a/ipynb_output_filter.py
+++ b/ipynb_output_filter.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     try:
         # New IPython
-        from IPython.nbformat import reads, write
+        from nbformat import reads, write
     except ImportError:
         # Old IPython
         from IPython.nbformat.current import reads, write


### PR DESCRIPTION
The old package name `IPython.nbformat` has been deprecated by the Jupyter project, as can be seen on http://blog.jupyter.org/2015/08/12/first-release-of-jupyter/

The change updates to the standalone package `nbformat` and means that the deprecation warning will no longer be seen.
