### PR TITLE
Drop the `metadata.language_info.version`

### DIFF
--- a/ipynb_output_filter.py
+++ b/ipynb_output_filter.py
@@ -57,6 +57,8 @@ for sheet in sheets:
     if hasattr(sheet.metadata, "widgets"):
         del sheet.metadata["widgets"]
 
+    if hasattr(sheet.metadata.language_info, "version"):
+        del sheet.metadata.language_info["version"]
 
 if 'signature' in json_in.metadata:
     json_in.metadata['signature'] = ""


### PR DESCRIPTION
Avoids generating irrelevant changes when opening the notebook with
a different but compatible language interpreter (say python 2.7.9 and
python 2.7.11).

The field is not documented to be important and it's automatically
generated/overwritten when starting the notebook.

It solves #12 
