### PR TITLE
Remove the `collapsed` and `scrolled` fields from cell metadata.

### DIFF
--- a/ipynb_output_filter.py
+++ b/ipynb_output_filter.py
@@ -54,6 +54,12 @@ for sheet in sheets:
         for field in ("execution_count",):
             if field in cell:
                 cell[field] = None
+
+        if "metadata" in cell:
+            for field in ("collapsed", "scrolled"):
+                if field in cell.metadata:
+                    del cell.metadata[field]
+
     if hasattr(sheet.metadata, "widgets"):
         del sheet.metadata["widgets"]
 


### PR DESCRIPTION
This fields control to display the output of a code cell and can be
changed from the notebook editor.

They can be annoying in the diffs. Besides, since the two properties
are reset when the cell is executed and the `ipynb_output_filter`
script is removing already the output of cells, there is no point
in keeping them.

resolves #11 
