### PR TITLE
Filter ExecuteTime metadata too

### DIFF
--- a/ipynb_output_filter.py
+++ b/ipynb_output_filter.py
@@ -56,7 +56,7 @@ for sheet in sheets:
                 cell[field] = None
 
         if "metadata" in cell:
-            for field in ("collapsed", "scrolled"):
+            for field in ("collapsed", "scrolled", "ExecuteTime"):
                 if field in cell.metadata:
                     del cell.metadata[field]
 


### PR DESCRIPTION
ExecuteTime is metadata written by the nbextension plugin:
http://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/execute_time/readme.html